### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,10 @@ setup(name = 'HiCHap',
       long_description = read('README.rst'),
       long_description_content_type = 'text/x-rst',
       scripts = glob.glob('scripts/*'),
-      packages = find_packages()
+      packages = find_packages(),
+      classifiers = [
+          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
+      ]
       )
       
 


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.